### PR TITLE
Updates Power Automate guide with fixes

### DIFF
--- a/src/Storingsdienst/Storingsdienst.Client/Pages/PowerAutomateGuide.razor
+++ b/src/Storingsdienst/Storingsdienst.Client/Pages/PowerAutomateGuide.razor
@@ -383,7 +383,10 @@
                                             </MudStack>
                                         </MudListItem>
                                         <MudListItem Class="param-item">
-                                            <MudText Typo="Typo.body2">@L["GuideStep6_FileContent"]</MudText>
+                                            <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
+                                                <MudText Typo="Typo.body2" Class="param-label">@L["GuideStep6_FileContent"]</MudText>
+                                                <CopyableCode Value="@("@outputs('Compose')")" OnCopy="ShowCopyConfirmation" />
+                                            </MudStack>
                                         </MudListItem>
                                     </MudList>
                                 </MudList>
@@ -456,8 +459,8 @@
   "events": [
     {
       "subject": "Project Standup",
-      "start": { "dateTime": "2024-01-15T09:00:00", "timeZone": "UTC" },
-      "end": { "dateTime": "2024-01-15T09:30:00", "timeZone": "UTC" },
+      "start": "2025-01-15T09:00:00+00:00",
+      "end": "2025-01-15T09:30:00+00:00",
       "isAllDay": false
     }
   ],

--- a/src/Storingsdienst/Storingsdienst.Client/wwwroot/appsettings.json
+++ b/src/Storingsdienst/Storingsdienst.Client/wwwroot/appsettings.json
@@ -1,7 +1,7 @@
 {
   "AzureAd": {
     "Authority": "https://login.microsoftonline.com/common",
-    "ClientId": "23ab765f-261f-4d10-8cc1-a4ca34a0ad38",
+    "ClientId": "YOUR_AZUREAD_CLIENT_ID",
     "ValidateAuthority": true
   },
   "MicrosoftGraph": {

--- a/src/Storingsdienst/Storingsdienst.Client/wwwroot/appsettings.json
+++ b/src/Storingsdienst/Storingsdienst.Client/wwwroot/appsettings.json
@@ -1,7 +1,7 @@
 {
   "AzureAd": {
     "Authority": "https://login.microsoftonline.com/common",
-    "ClientId": "YOUR_AZUREAD_CLIENT_ID",
+    "ClientId": "23ab765f-261f-4d10-8cc1-a4ca34a0ad38",
     "ValidateAuthority": true
   },
   "MicrosoftGraph": {

--- a/src/Storingsdienst/Storingsdienst/wwwroot/locales/en.json
+++ b/src/Storingsdienst/Storingsdienst/wwwroot/locales/en.json
@@ -157,7 +157,7 @@
     "GuideStep6_ConfigureFile":  "Configure File Settings:",
     "GuideStep6_FolderPath":  "Folder Path:",
     "GuideStep6_FileName":  "File Name:",
-    "GuideStep6_FileContent":  "File Content: Select \"Outputs\" from the Compose step",
+    "GuideStep6_FileContent":  "File Content:",
     "GuideStep6_CreateFolder":  "Note: Create the folder /Documents/CalendarExports in OneDrive before running the flow.",
     "GuideStep6_SharePointAlt":  "Alternative: You can use SharePoint instead of OneDrive by selecting \"SharePoint\" - \"Create file\" and choosing your site.",
     "GuideStep7Title":  "Step 7: Test \u0026 Export Your Flow",

--- a/src/Storingsdienst/Storingsdienst/wwwroot/locales/nl.json
+++ b/src/Storingsdienst/Storingsdienst/wwwroot/locales/nl.json
@@ -157,7 +157,7 @@
     "GuideStep6_ConfigureFile":  "Bestandsinstellingen configureren:",
     "GuideStep6_FolderPath":  "Mappad:",
     "GuideStep6_FileName":  "Bestandsnaam:",
-    "GuideStep6_FileContent":  "Bestandsinhoud: Selecteer \"Uitvoer\" van de Opstellen stap",
+    "GuideStep6_FileContent":  "Bestandsinhoud:",
     "GuideStep6_CreateFolder":  "Let op: Maak de map /Documents/CalendarExports aan in OneDrive voordat u de flow uitvoert.",
     "GuideStep6_SharePointAlt":  "Alternatief: U kunt ook SharePoint gebruiken in plaats van OneDrive door \"SharePoint\" - \"Bestand maken\" te selecteren.",
     "GuideStep7Title":  "Stap 7: Testen \u0026 Exporteren",


### PR DESCRIPTION
Updates the Power Automate guide with a copyable code snippet for file content and corrects the date format in the example. Also updates the Azure AD ClientId.

The guide now includes a "CopyableCode" component allowing the user to copy the compose output directly, removing ambiguity.

The date format in the example JSON payload has been corrected to ISO 8601 format (YYYY-MM-DDTHH:mm:ss+00:00), ensuring compatibility and preventing potential errors.
